### PR TITLE
fix error on close

### DIFF
--- a/src/main/java/io/github/tkjonesy/frontend/models/CameraFetcher.java
+++ b/src/main/java/io/github/tkjonesy/frontend/models/CameraFetcher.java
@@ -102,13 +102,16 @@ public class CameraFetcher implements Runnable {
 
                     // Overlay predictions & resize
                     ImageUtil.drawPredictions(frame, detections);
+                    try {
+                        resize(frame, frame, new Size(cameraFeed.getWidth(), cameraFeed.getHeight()));
 
-                    resize(frame, frame, new Size(cameraFeed.getWidth(), cameraFeed.getHeight()));
-
-                    // Show frame in label
-                    BufferedImage biFrame = cvt2bi(frame);
-                    cameraFeed.setIcon(new ImageIcon(biFrame));
-
+                        // Show frame in label
+                        BufferedImage biFrame = cvt2bi(frame);
+                        cameraFeed.setIcon(new ImageIcon(biFrame));
+                    } catch (Exception e ){
+                        System.out.println("Camera Fetcher had to stop! If you are closing the program, this is expected.");
+                        this.cancel();
+                    }
                     // Write the frame to the video file if the session is active
                     VideoWriter writer = fileSession.getVideoWriter();
                     if (fileSession.isSessionActive()) {


### PR DESCRIPTION
Fixed the error on application close. This was caused by killing the thread by not checking if the TimerTask was still running. The timer task will now run and if it errors out, it simply says that if the application is being closed, this is normal. This will be the set solution unless another issue arises because of it (For example, if the CameraFetcher says it's closing, when the application is not being closed)