### PR TITLE
[FEATURE] Truncate Log Time Stamps

### DIFF
--- a/src/main/java/io/github/tkjonesy/ONNX/models/InferenceLog.java
+++ b/src/main/java/io/github/tkjonesy/ONNX/models/InferenceLog.java
@@ -3,6 +3,8 @@ package io.github.tkjonesy.ONNX.models;
 import io.github.tkjonesy.ONNX.enums.InferenceLogEnum;
 import lombok.Getter;
 
+import java.time.temporal.ChronoUnit;
+
 /**
  * The {@code Log} class represents a log entry with a log type, message, and timestamp.
  * It provides methods for generating logs with a timestamp and displaying them in a UI component.
@@ -37,6 +39,6 @@ public class InferenceLog {
      * @return The formatted current timestamp.
      */
     private String getCurrentTimestamp(){
-        return "[" + java.time.LocalTime.now() + "]";
+        return "[" + java.time.LocalTime.now().truncatedTo(ChronoUnit.SECONDS) + "]";
     }
 }


### PR DESCRIPTION
# Proposed Changes

## Description

Time stamps in the log are now truncated down to seconds, instead of nanoseconds.

## Type of Change

Choose all that applies:

- [ ] Code cleanup (non-breaking change that does not affect functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The program was run and a session was started to view the updated time stamps to ensure it only showed time in HH:MM:SS format.

*Test(s) Performed:*

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
