### PR TITLE
[BUG_FIX] Fix deployment with new version names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,9 @@
 name: Release on PR Merge
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
-    types:
-      - opened
-      - synchronize
-      - closed
+      - *
 
 permissions:
   contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,9 @@
 name: Release on PR Merge
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
-    types:
-      - opened
-      - synchronize
-      - closed
+      - *
 permissions:
   contents: write
   pull-requests: read
@@ -90,13 +86,20 @@ jobs:
       - name: Build JAR
         run: mvn clean package
 
+      - name: Find generated .jar
+        id: find-jar
+        run: |
+            JAR_PATH=$(find target -name "AIMs-*.jar" -type f | head -n 1)
+            echo "JAR_PATH=$JAR_PATH" >> $GITHUB_ENV
+            echo "Found JAR file at: $JAR_PATH"
+
       - name: Build .dmg via jPackage
         run: |
           jpackage \
             --input target/ \
             --dest target/ \
             --name "AIMs" \
-            --main-jar AIMs-1.0-SNAPSHOT.jar \
+            --main-jar "$JAR_FILE" \
             --main-class io.github.tkjonesy.frontend.App \
             --icon "src/main/resources/images/aims_logo.icns" \
             --type dmg \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,13 @@
 name: Release on PR Merge
 
 on:
-  push:
+  pull_request:
     branches:
-      - '**'
+      - main
+    types:
+      - opened
+      - synchronize
+      - closed
 
 permissions:
   contents: write
@@ -46,9 +50,10 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'maven'
 
       - name: Build JAR
-        run: mvn clean package
+        run: mvn clean -B package
 
       - name: Build Installer
         run: |
@@ -83,9 +88,10 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'maven'
 
       - name: Build JAR
-        run: mvn clean package
+        run: mvn clean -B package
 
       - name: Build .dmg via jPackage
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,13 @@
 name: Release on PR Merge
 
 on:
-  push:
+  pull_request:
     branches:
-      - '**'
+      - main
+    types:
+      - opened
+      - synchronize
+      - closed
 
 permissions:
   contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Release on PR Merge
 on:
   push:
     branches:
-      - *
+      - '**'
 
 permissions:
   contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,12 +50,19 @@ jobs:
       - name: Build JAR
         run: mvn clean package
 
+      - name: Find generated .jar
+        id: find-jar
+        run: |
+          JAR_PATH=$(find target -name "AIMs-*.jar" -type f | head -n 1)
+          echo "JAR_PATH=$JAR_PATH" >> $GITHUB_ENV
+          echo "Found JAR file at: $JAR_PATH"
+
       - name: Build Installer
         run: |
           jpackage --name "AIMs" `
           --input target/ `
           --dest target/ `
-          --main-jar AIMs-1.0-SNAPSHOT.jar `
+          --main-jar "$JAR_PATH" `
           --main-class io.github.tkjonesy.frontend.App `
           --icon "src/main/resources/images/logo.ico" `
           --type exe `
@@ -100,7 +107,7 @@ jobs:
             --input target/ \
             --dest target/ \
             --name "AIMs" \
-            --main-jar "$JAR_FILE" \
+            --main-jar "$JAR_PATH" \
             --main-class io.github.tkjonesy.frontend.App \
             --icon "src/main/resources/images/aims_logo.icns" \
             --type dmg \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,19 +50,12 @@ jobs:
       - name: Build JAR
         run: mvn clean package
 
-      - name: Find generated .jar
-        id: find-jar
-        run: |
-          JAR_PATH=$(find target -name "AIMs-*.jar" -type f | head -n 1)
-          echo "JAR_PATH=$JAR_PATH" >> $GITHUB_ENV
-          echo "Found JAR file at: $JAR_PATH"
-
       - name: Build Installer
         run: |
           jpackage --name "AIMs" `
           --input target/ `
           --dest target/ `
-          --main-jar "$JAR_PATH" `
+          --main-jar "$JAR_FILE" `
           --main-class io.github.tkjonesy.frontend.App `
           --icon "src/main/resources/images/logo.ico" `
           --type exe `
@@ -94,20 +87,13 @@ jobs:
       - name: Build JAR
         run: mvn clean package
 
-      - name: Find generated .jar
-        id: find-jar
-        run: |
-            JAR_PATH=$(find target -name "AIMs-*.jar" -type f | head -n 1)
-            echo "JAR_PATH=$JAR_PATH" >> $GITHUB_ENV
-            echo "Found JAR file at: $JAR_PATH"
-
       - name: Build .dmg via jPackage
         run: |
           jpackage \
             --input target/ \
             --dest target/ \
             --name "AIMs" \
-            --main-jar "$JAR_PATH" \
+            --main-jar "$JAR_FILE" \
             --main-class io.github.tkjonesy.frontend.App \
             --icon "src/main/resources/images/aims_logo.icns" \
             --type dmg \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,8 @@ name: Release on PR Merge
 on:
   push:
     branches:
-      - *
+      - '**'
+
 permissions:
   contents: write
   pull-requests: read


### PR DESCRIPTION
# Bug Fix

## Problem
Mac and Windows jPackage .jar name needed to be changed to reflect the new version scheme.

## Solution
Used $JAR_FILE as the file name for jPackage

## Testing
Ran the Mac and Windows tests multiple times and downloaded the Mac .dmg to see if it ran. 
