### PR TITLE
[FEATURE] Add setting for onnx thread count

### DIFF
--- a/src/main/java/io/github/tkjonesy/ONNX/ImageUtil.java
+++ b/src/main/java/io/github/tkjonesy/ONNX/ImageUtil.java
@@ -1,5 +1,6 @@
 package io.github.tkjonesy.ONNX;
 
+import io.github.tkjonesy.utils.logging.AIMsLogger;
 import io.github.tkjonesy.utils.settings.ProgramSettings;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.Point;
@@ -105,7 +106,12 @@ public class ImageUtil {
 
         for (Detection detection : detectionList) {
             float[] bbox = detection.bbox();
+
             int[] boundingBoxColor = settings.getBoundingBoxColor();
+            if(boundingBoxColor.length != 3){
+                boundingBoxColor = new int[]{255, 0, 0};
+            }
+
             Scalar color = new Scalar(boundingBoxColor[2], boundingBoxColor[1], boundingBoxColor[0], 0);
             rectangle(img,                    // Matrix object of the image
                     new Point((int) bbox[0], (int) bbox[1]),      // Top-left point

--- a/src/main/java/io/github/tkjonesy/ONNX/Yolo.java
+++ b/src/main/java/io/github/tkjonesy/ONNX/Yolo.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 
 public abstract class Yolo {
 
+    private static final ProgramSettings settings = ProgramSettings.getCurrentSettings();
+
     @Getter
     private static boolean isCudaAvailable = false;
 
@@ -34,7 +36,7 @@ public abstract class Yolo {
         EnumSet<OrtProvider> availableProviders = OrtEnvironment.getAvailableProviders();
         AIMsLogger.INFO("Available providers: " + availableProviders);
         
-        boolean useGPU = availableProviders.contains(OrtProvider.CUDA) && ProgramSettings.getCurrentSettings().isUseGPU();
+        boolean useGPU = availableProviders.contains(OrtProvider.CUDA) && settings.isUseGPU();
         SessionOptions sessionOptions = createSessionOptions(useGPU);
 
         try {
@@ -76,7 +78,7 @@ public abstract class Yolo {
         if (useGPU) {
             try {
                 AIMsLogger.INFO("Attempting to add CUDA provider...");
-                sessionOptions.addCUDA(ProgramSettings.getCurrentSettings().getGpuDeviceId());
+                sessionOptions.addCUDA(settings.getGpuDeviceId());
                 AIMsLogger.INFO("CUDA provider added successfully.");
             } catch (OrtException e) {
                 AIMsLogger.INFO("Failed to add CUDA provider, falling back to CPU: " + e.getMessage());
@@ -87,8 +89,8 @@ public abstract class Yolo {
 
         if (!useGPU) {
             sessionOptions.addCPU(true);
-            sessionOptions.setInterOpNumThreads(1);
-            sessionOptions.setIntraOpNumThreads(1);
+            sessionOptions.setInterOpNumThreads(settings.getNumOnnxThreads());
+            sessionOptions.setIntraOpNumThreads(settings.getNumOnnxThreads());
             AIMsLogger.INFO("Using CPU for inference.");
         }
 

--- a/src/main/java/io/github/tkjonesy/ONNX/enums/InferenceLogEnum.java
+++ b/src/main/java/io/github/tkjonesy/ONNX/enums/InferenceLogEnum.java
@@ -14,7 +14,7 @@ import java.awt.Color;
 public enum InferenceLogEnum {
     INFO(Color.YELLOW),
     LOG_ADDED(Color.GREEN),
-    LOG_REMOVED(Color.RED); // Defaults are now set in ProgramSettings
+    LOG_REMOVED(Color.RED);
 
     private Color color;
 

--- a/src/main/java/io/github/tkjonesy/frontend/settingsGUI/panels/AISettingsPanel.java
+++ b/src/main/java/io/github/tkjonesy/frontend/settingsGUI/panels/AISettingsPanel.java
@@ -86,6 +86,7 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
 
         this.colorLabel = new JLabel("Bounding box color (RGB):");
 
+        int[] boundingBoxColor = settings.getBoundingBoxColor();
         int r = settings.getBoundingBoxColor()[0];
         int g = settings.getBoundingBoxColor()[1];
         int b = settings.getBoundingBoxColor()[2];
@@ -126,7 +127,7 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
 
         this.logAddedColorPreviewButton = createColorPreviewButton(logAddedR, logAddedG, logAddedB, this::openLogAddedColorChooser);
 
-// Initialize Log Removed Color
+        // Initialize Log Removed Color
         int logRemovedR = settings.getLogRemovedColor()[0];
         int logRemovedG = settings.getLogRemovedColor()[1];
         int logRemovedB = settings.getLogRemovedColor()[2];
@@ -566,7 +567,6 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
 
         colorDialog.setVisible(true);
     }
-
 
     // Ensure only the "Swatches" and "RGB" tabs are visible
     private void removeUnwantedTabs(JColorChooser colorChooser) {

--- a/src/main/java/io/github/tkjonesy/frontend/settingsGUI/panels/AdvancedSettingsPanel/AdvancedAISection.java
+++ b/src/main/java/io/github/tkjonesy/frontend/settingsGUI/panels/AdvancedSettingsPanel/AdvancedAISection.java
@@ -33,6 +33,7 @@ public class AdvancedAISection extends JPanel implements SettingsUI {
     private final JLabel useGPULabel;
     private final JLabel nmsThresholdLabel;
     private final JLabel optimizationLabel;
+    private final JLabel numOnnxThreadsLabel;
     private final JLabel inputSizeLabel;
     private final JLabel inputShapeLabel;
 
@@ -42,6 +43,7 @@ public class AdvancedAISection extends JPanel implements SettingsUI {
     private final JSlider nmsThresholdSlider;
     private final JTextField nmsThresholdTextField;
     private final JComboBox<String> optimizationLevelComboBox;
+    private final JSpinner numOnnxThreadsSpinner;
     private final JSpinner inputSizeSpinner;
     private final JTextField inputShapeTextField;
 
@@ -110,17 +112,25 @@ public class AdvancedAISection extends JPanel implements SettingsUI {
         optimizationLevelComboBox = new JComboBox<>(new String[]{"ALL_OPT", "EXTENDED_OPT", "BASIC_OPT", "NO_OPT"});
         optimizationLevelComboBox.setSelectedItem(settings.getOptimizationLevel().name());
         optimizationLevelComboBox.setToolTipText("Choose the level of ONNX Runtime optimizations.");
+        optimizationLevelComboBox.setPreferredSize(new Dimension(100, optimizationLevelComboBox.getPreferredSize().height));
+
+        // Number of ONNX Threads (Spinner)
+        this.numOnnxThreadsLabel = new JLabel("Number of ONNX Threads:");
+        numOnnxThreadsSpinner = new JSpinner(new SpinnerNumberModel(settings.getNumOnnxThreads(), 1, Integer.MAX_VALUE, 1));
+        numOnnxThreadsSpinner.setToolTipText("Number of threads to use for ONNX Runtime. Increase if your device takes longer to process inferences.");
+        numOnnxThreadsSpinner.setPreferredSize(new Dimension(60, numOnnxThreadsSpinner.getPreferredSize().height));
 
         // Input Size (Spinner)
         this.inputSizeLabel = new JLabel("Input Size:");
         inputSizeSpinner = new JSpinner(new SpinnerNumberModel(settings.getInputSize(), 1, Integer.MAX_VALUE, 1));
         inputSizeSpinner.setToolTipText("The input image size (e.g., 640 for YOLO).");
+        inputSizeSpinner.setPreferredSize(new Dimension(70, inputSizeSpinner.getPreferredSize().height));
 
         // Input Shape (TextField)
         this.inputShapeLabel = new JLabel("Input Shape:");
         inputShapeTextField = new JTextField(
                 Arrays.stream(settings.getInputShape()).mapToObj(String::valueOf).collect(Collectors.joining(", ")),
-                20
+                10
         );
         inputShapeTextField.setToolTipText("Comma-separated input shape (e.g., 1,3,640,640)");
 
@@ -204,6 +214,16 @@ public class AdvancedAISection extends JPanel implements SettingsUI {
                 }
         );
 
+        addSettingChangeListener(numOnnxThreadsSpinner, (ChangeListener)
+                e -> {
+                    int value = (int) numOnnxThreadsSpinner.getValue();
+                    AIMsLogger.TRACE("Number of ONNX Threads: " + value);
+                    settingsUpdates.put("numOnnxThreads", value);
+                    if(settings.getNumOnnxThreads() == value)
+                        settingsUpdates.remove("numOnnxThreads");
+                }
+        );
+
         addSettingChangeListener(inputSizeSpinner, (ChangeListener)
                 e -> {
                     int value = (int) inputSizeSpinner.getValue();
@@ -277,6 +297,10 @@ public class AdvancedAISection extends JPanel implements SettingsUI {
                                 .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
                                 .addComponent(optimizationLevelComboBox, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
                         .addGroup(layout.createSequentialGroup()
+                                .addComponent(numOnnxThreadsLabel)
+                                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(numOnnxThreadsSpinner, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                        .addGroup(layout.createSequentialGroup()
                                 .addComponent(inputSizeLabel)
                                 .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
                                 .addComponent(inputSizeSpinner, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
@@ -306,6 +330,10 @@ public class AdvancedAISection extends JPanel implements SettingsUI {
                         .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(optimizationLabel)
                                 .addComponent(optimizationLevelComboBox))
+                        .addPreferredGap(LayoutStyle.ComponentPlacement.UNRELATED)
+                        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                .addComponent(numOnnxThreadsLabel)
+                                .addComponent(numOnnxThreadsSpinner))
                         .addPreferredGap(LayoutStyle.ComponentPlacement.UNRELATED)
                         .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(inputSizeLabel)

--- a/src/main/java/io/github/tkjonesy/utils/settings/ProgramSettings.java
+++ b/src/main/java/io/github/tkjonesy/utils/settings/ProgramSettings.java
@@ -81,6 +81,8 @@ public class ProgramSettings {
     private float nmsThreshold;
     @SettingsLabel(value = "optimizationLevel", type = OrtSession.SessionOptions.OptLevel.class) // all, extended, basic, no
     private OrtSession.SessionOptions.OptLevel optimizationLevel;
+    @SettingsLabel(value = "numOnnxThreads", type = Integer.class)
+    private int numOnnxThreads;
     @SettingsLabel(value = "inputSize", type = Integer.class)
     private int inputSize;
     @SettingsLabel(value = "inputShape", type = long[].class)
@@ -106,7 +108,8 @@ public class ProgramSettings {
         for (String key : newSettings.keySet()) {
             setSettings(key, newSettings.get(key));
 
-            if (key.equals("modelPath") || key.equals("labelPath") || key.equals("useGPU")) {
+            if (key.equals("modelPath") || key.equals("labelPath") || key.equals("useGPU") || key.equals("gpuDeviceId") ||
+                    key.equals("optimizationLevel") || key.equals("numOnnxThreads")) {
                 updateONNX = true;
             }
             if (key.equals("cameraDeviceId")) {

--- a/src/main/java/io/github/tkjonesy/utils/settings/ProgramSettings.java
+++ b/src/main/java/io/github/tkjonesy/utils/settings/ProgramSettings.java
@@ -24,11 +24,11 @@ public class ProgramSettings {
 
     // Camera variables
     @SettingsLabel(value = "cameraDeviceId", type = Integer.class)
-    private int cameraDeviceId;
+    private int cameraDeviceId = 0;
     @SettingsLabel(value = "cameraFps", type = Integer.class)
-    private int cameraFps;
+    private int cameraFps = 30;
     @SettingsLabel(value = "cameraRotation", type = Integer.class)
-    private int cameraRotation;
+    private int cameraRotation = 0;
     @SettingsLabel(value = "mirrorCamera", type = Boolean.class)
     private boolean mirrorCamera;
     @SettingsLabel(value = "preserveAspectRatio", type = Boolean.class)
@@ -53,11 +53,11 @@ public class ProgramSettings {
     @SettingsLabel(value = "labelPath", type = String.class)
     private String labelPath;
     @SettingsLabel(value = "boundingBoxColor", type = int[].class)
-    private int[] boundingBoxColor;
+    private int[] boundingBoxColor = {255, 0, 0};
     @SettingsLabel(value = "logAddedColor", type = int[].class)
-    private int[] logAddedColor;
+    private int[] logAddedColor = {0, 255, 0};
     @SettingsLabel(value = "logRemovedColor", type = int[].class)
-    private int[] logRemovedColor;
+    private int[] logRemovedColor = {255, 0, 0};
     @SettingsLabel(value = "showBoundingBoxes", type = Boolean.class)
     private boolean showBoundingBoxes;
     @SettingsLabel(value = "showLabels", type = Boolean.class)
@@ -65,40 +65,37 @@ public class ProgramSettings {
     @SettingsLabel(value = "showConfidences", type = Boolean.class)
     private boolean showConfidences;
     @SettingsLabel(value = "processEveryNthFrame", type = Integer.class)
-    private int processEveryNthFrame;
+    private int processEveryNthFrame = 30;
     @SettingsLabel(value = "bufferThreshold", type = Integer.class)
-    private int bufferThreshold;
+    private int bufferThreshold = 3;
     @SettingsLabel(value = "confThreshold", type = Float.class)
-    private float confThreshold;
+    private float confThreshold = 0.6f;
 
     // Advanced AI settings
     @Setter
     @SettingsLabel(value = "useGPU", type = Boolean.class)
     private boolean useGPU;
     @SettingsLabel(value = "gpuDeviceId", type = Integer.class)
-    private int gpuDeviceId;
+    private int gpuDeviceId = 0;
     @SettingsLabel(value = "nmsThreshold", type = Float.class)
-    private float nmsThreshold;
+    private float nmsThreshold = 0.45f;
     @SettingsLabel(value = "optimizationLevel", type = OrtSession.SessionOptions.OptLevel.class) // all, extended, basic, no
-    private OrtSession.SessionOptions.OptLevel optimizationLevel;
+    private OrtSession.SessionOptions.OptLevel optimizationLevel = OrtSession.SessionOptions.OptLevel.ALL_OPT;
     @SettingsLabel(value = "numOnnxThreads", type = Integer.class)
-    private int numOnnxThreads;
+    private int numOnnxThreads = 1;
     @SettingsLabel(value = "inputSize", type = Integer.class)
-    private int inputSize;
+    private int inputSize = 640;
     @SettingsLabel(value = "inputShape", type = long[].class)
-    private long[] inputShape;
+    private long[] inputShape = {1, 3, 640, 640};
     @SettingsLabel(value = "numInputElements", type = Integer.class)
     private int numInputElements;
 
     @SettingsLabel(value = "debugMode", type = Boolean.class)
     private boolean debugMode;
     @SettingsLabel(value = "continuousLogging", type = Boolean.class)
-    private boolean continuousLogging;
+    private boolean continuousLogging = true;
     @SettingsLabel(value = "showInferenceTime", type = Boolean.class)
     private boolean showInferenceTime;
-
-    @SettingsLabel(value = "notZeroNum", type = Integer.class)
-    private int notZeroNum;
 
     // -------------------------------------------------------------------------
 

--- a/src/main/java/io/github/tkjonesy/utils/settings/SettingsLoader.java
+++ b/src/main/java/io/github/tkjonesy/utils/settings/SettingsLoader.java
@@ -19,16 +19,13 @@ public class SettingsLoader {
 
     // Default model to use if none is specified
     private static final String DEFAULT_MODEL = "yolo11m";
+    private static final ProgramSettings DEFAULT_SETTINGS = loadSettingsFromResource(new ObjectMapper());
 
     public static void resetToDefaultSettings(){
-        // Load default settings from resources
-        ObjectMapper objectMapper = new ObjectMapper();
-        ProgramSettings defaultSettings = loadSettingsFromResource(objectMapper);
-
         // Save the default settings to the file
-        if(defaultSettings != null){
-            saveSettings(defaultSettings);
-            ProgramSettings.setCurrentSettings(defaultSettings);
+        if(DEFAULT_SETTINGS != null){
+            saveSettings(DEFAULT_SETTINGS);
+            ProgramSettings.setCurrentSettings(DEFAULT_SETTINGS);
             AIMsLogger.WARN("Reset settings to default.");
         }
     }
@@ -51,10 +48,9 @@ public class SettingsLoader {
 
             // Ensure all the values in the current settings are set. Compare to default settings.
             // If not set, assign default values.
-            ProgramSettings defaultSettings = loadSettingsFromResource(objectMapper);
-            if (defaultSettings != null) {
-                syncMissingFields(settings, defaultSettings);
-            }
+//            if (DEFAULT_SETTINGS != null) {
+//                sanitizeBrokenFields(settings);
+//            }
 
             if(settings.getFileDirectory() == null){
                 settings.setFileDirectory(DEFAULT_AIMS_SESSIONS_DIRECTORY);
@@ -65,40 +61,6 @@ public class SettingsLoader {
         }
 
         return settings;
-    }
-
-    private static void syncMissingFields(ProgramSettings userSettings, ProgramSettings defaultSettings) {
-        try {
-            // Get all fields from the ProgramSettings class
-            Field[] fields = ProgramSettings.class.getDeclaredFields();
-
-            // Add missing fields from default settings
-            for (Field field : fields) {
-                field.setAccessible(true);
-                Object defaultValue = field.get(defaultSettings);
-                Object userValue = field.get(userSettings);
-
-                // If the user's value is null but the default has a value, copy it over
-                if (userValue == null && defaultValue != null) {
-                    field.set(userSettings, defaultValue);
-                }
-            }
-
-            // Remove extra fields not defined in ProgramSettings
-            ObjectMapper mapper = new ObjectMapper();
-            String json = mapper.writeValueAsString(userSettings);
-            ProgramSettings cleanSettings = mapper.readValue(json, ProgramSettings.class);
-
-            // Copy all values from cleanSettings back to userSettings
-            for (Field field : fields) {
-                field.setAccessible(true);
-                Object cleanValue = field.get(cleanSettings);
-                field.set(userSettings, cleanValue);
-            }
-
-        } catch (IllegalAccessException | IOException e) {
-            AIMsLogger.ERROR("Failed to sync settings fields: " + e.getMessage());
-        }
     }
 
     public static void initializeAIMsDirectories() {
@@ -127,12 +89,7 @@ public class SettingsLoader {
         File settingsFile = new File(AIMS_SETTINGS_FILE_PATH);
         if (settingsFile.exists()) {
             try {
-                ProgramSettings settings = objectMapper.readValue(settingsFile, ProgramSettings.class);
-                if(settings.getNotZeroNum() == 0){
-                    return null;
-                }else{
-                    return settings;
-                }
+                return objectMapper.readValue(settingsFile, ProgramSettings.class);
             } catch (IOException e) {
                 AIMsLogger.ERROR("Failed to load settings from file: " + e.getMessage());
             }

--- a/src/main/resources/defaultSettings.json
+++ b/src/main/resources/defaultSettings.json
@@ -26,6 +26,7 @@
   "gpuDeviceId": 0,
   "nmsThreshold": 0.45,
   "optimizationLevel": "ALL_OPT",
+  "numOnnxThreads": 3,
   "numInputElements": 1228800,
   "inputSize": 640,
   "inputShape": [1, 3, 640, 640],

--- a/src/main/resources/defaultSettings.json
+++ b/src/main/resources/defaultSettings.json
@@ -33,7 +33,5 @@
 
   "continuousLogging": true,
   "debugMode": false,
-  "showInferenceTime": false,
-
-  "notZeroNum": 1
+  "showInferenceTime": false
 }


### PR DESCRIPTION
# Proposed Changes

## Description

Added a setting for the number of threads onnx runtime will use. Also added default values to some of the settings to prevent crashes. If a field was missing (out of date settings) then the field would be set to Java's default. Which is fine unless it is something like cameraFPS where we are dividing by it. Then we would get an arithmetic exception.

## Type of Change

Choose all that applies:

- [x] Code cleanup (non-breaking change that does not affect functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

*Test(s) Performed:*

Tested by deleting different values from my own settings.json and saw the ProgramSettings be generated properly with good default variables.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
