### PR TITLE
[BUG_FIX] Cleaned and simplified some of the color changing code in AiSettingPanel.java

### DIFF
--- a/src/main/java/io/github/tkjonesy/ONNX/enums/InferenceLogEnum.java
+++ b/src/main/java/io/github/tkjonesy/ONNX/enums/InferenceLogEnum.java
@@ -2,7 +2,6 @@ package io.github.tkjonesy.ONNX.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import io.github.tkjonesy.utils.settings.ProgramSettings;
 import java.awt.Color;
 
 /**

--- a/src/main/java/io/github/tkjonesy/ONNX/enums/colorChangeEnum.java
+++ b/src/main/java/io/github/tkjonesy/ONNX/enums/colorChangeEnum.java
@@ -1,0 +1,14 @@
+package io.github.tkjonesy.ONNX.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum colorChangeEnum {
+    BOUNDINGBOX(1),
+    LOGADDED(2),
+    LOGREMOVED(3);
+
+    private final int code;
+}

--- a/src/main/java/io/github/tkjonesy/frontend/App.java
+++ b/src/main/java/io/github/tkjonesy/frontend/App.java
@@ -30,6 +30,7 @@ import io.github.tkjonesy.utils.models.LogHandler;
 import io.github.tkjonesy.utils.models.SessionHandler;
 import io.github.tkjonesy.utils.settings.ProgramSettings;
 import io.github.tkjonesy.utils.settings.SettingsLoader;
+import io.github.tkjonesy.ONNX.enums.InferenceLogEnum;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -128,6 +129,9 @@ public class App extends JFrame {
 
     private void initializeSettingsAndLogger() {
         this.settings = SettingsLoader.loadSettings();
+
+        InferenceLogEnum.LOG_ADDED.updateColor(settings.getLogAddedColor());
+        InferenceLogEnum.LOG_REMOVED.updateColor(settings.getLogRemovedColor());
 
         if (settings == null) {
             AIMsLogger.ERROR("Failed to load settings from file. Exiting application.");

--- a/src/main/java/io/github/tkjonesy/frontend/settingsGUI/panels/AISettingsPanel.java
+++ b/src/main/java/io/github/tkjonesy/frontend/settingsGUI/panels/AISettingsPanel.java
@@ -4,6 +4,7 @@ import io.github.tkjonesy.frontend.settingsGUI.SettingsUI;
 import io.github.tkjonesy.frontend.settingsGUI.SettingsWindow;
 import io.github.tkjonesy.utils.logging.AIMsLogger;
 import io.github.tkjonesy.utils.settings.ProgramSettings;
+import io.github.tkjonesy.ONNX.enums.colorChangeEnum;
 
 import javax.swing.*;
 import javax.swing.event.ChangeListener;
@@ -96,9 +97,9 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
         this.gInputTextField = new JTextField(String.valueOf(g), 3);
         this.bInputTextField = new JTextField(String.valueOf(b), 3);
 
-        rInputTextField.addActionListener(e -> updateColor(1));
-        gInputTextField.addActionListener(e -> updateColor(1));
-        bInputTextField.addActionListener(e -> updateColor(1));
+        rInputTextField.addActionListener(e -> updateColor(colorChangeEnum.BOUNDINGBOX.getCode()));
+        gInputTextField.addActionListener(e -> updateColor(colorChangeEnum.BOUNDINGBOX.getCode()));
+        bInputTextField.addActionListener(e -> updateColor(colorChangeEnum.BOUNDINGBOX.getCode()));
 
         this.colorPreviewButton = new JButton() {
             @Override
@@ -122,9 +123,9 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
         this.logAddedGInputTextField = new JTextField(String.valueOf(logAddedG), 3);
         this.logAddedBInputTextField = new JTextField(String.valueOf(logAddedB), 3);
 
-        logAddedRInputTextField.addActionListener(e -> updateColor(2));
-        logAddedGInputTextField.addActionListener(e -> updateColor(2));
-        logAddedBInputTextField.addActionListener(e -> updateColor(2));
+        logAddedRInputTextField.addActionListener(e -> updateColor(colorChangeEnum.LOGADDED.getCode()));
+        logAddedGInputTextField.addActionListener(e -> updateColor(colorChangeEnum.LOGADDED.getCode()));
+        logAddedBInputTextField.addActionListener(e -> updateColor(colorChangeEnum.LOGADDED.getCode()));
 
         this.logAddedColorPreviewButton = createColorPreviewButton(logAddedR, logAddedG, logAddedB, this::openLogAddedColorChooser);
 
@@ -137,9 +138,9 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
         this.logRemovedGInputTextField = new JTextField(String.valueOf(logRemovedG), 3);
         this.logRemovedBInputTextField = new JTextField(String.valueOf(logRemovedB), 3);
 
-        logRemovedRInputTextField.addActionListener(e -> updateColor(3));
-        logRemovedGInputTextField.addActionListener(e -> updateColor(3));
-        logRemovedBInputTextField.addActionListener(e -> updateColor(3));
+        logRemovedRInputTextField.addActionListener(e -> updateColor(colorChangeEnum.LOGREMOVED.getCode()));
+        logRemovedGInputTextField.addActionListener(e -> updateColor(colorChangeEnum.LOGREMOVED.getCode()));
+        logRemovedBInputTextField.addActionListener(e -> updateColor(colorChangeEnum.LOGREMOVED.getCode()));
 
         this.logRemovedColorPreviewButton = createColorPreviewButton(logRemovedR, logRemovedG, logRemovedB, this::openLogRemovedColorChooser);
 

--- a/src/main/java/io/github/tkjonesy/frontend/settingsGUI/panels/AISettingsPanel.java
+++ b/src/main/java/io/github/tkjonesy/frontend/settingsGUI/panels/AISettingsPanel.java
@@ -2,8 +2,6 @@ package io.github.tkjonesy.frontend.settingsGUI.panels;
 
 import io.github.tkjonesy.frontend.settingsGUI.SettingsUI;
 import io.github.tkjonesy.frontend.settingsGUI.SettingsWindow;
-import io.github.tkjonesy.frontend.settingsGUI.listenersANDevents.AISettingsListener;
-import io.github.tkjonesy.frontend.settingsGUI.listenersANDevents.BoundingBoxColorChangeEvent;
 import io.github.tkjonesy.utils.logging.AIMsLogger;
 import io.github.tkjonesy.utils.settings.ProgramSettings;
 
@@ -56,7 +54,6 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
     private final JLabel logAddedColorLabel = new JLabel("Log Added Color (RGB):");
     private final JLabel logRemovedColorLabel = new JLabel("Log Removed Color (RGB):");
 
-
     private final JComboBox<String> modelSelector;
     private final JComboBox<String> labelSelector;
     private final JCheckBox boundingBoxCheckbox;
@@ -68,6 +65,10 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
     private final JTextField confThresholdTextField;
 
     private final List<AISettingsListener> listeners = new ArrayList<>();
+
+    public interface AISettingsListener {
+        void onColorChanged(String settingKey, int[] newColor);
+    }
 
     public AISettingsPanel() {
         this.noticeLabel = new JLabel("<html><b>Only YOLOv8+ models in .onnx format are supported.</b></html>");
@@ -95,9 +96,9 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
         this.gInputTextField = new JTextField(String.valueOf(g), 3);
         this.bInputTextField = new JTextField(String.valueOf(b), 3);
 
-        rInputTextField.addActionListener(e -> updateBoundingBoxColor());
-        gInputTextField.addActionListener(e -> updateBoundingBoxColor());
-        bInputTextField.addActionListener(e -> updateBoundingBoxColor());
+        rInputTextField.addActionListener(e -> updateColor(1));
+        gInputTextField.addActionListener(e -> updateColor(1));
+        bInputTextField.addActionListener(e -> updateColor(1));
 
         this.colorPreviewButton = new JButton() {
             @Override
@@ -121,9 +122,9 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
         this.logAddedGInputTextField = new JTextField(String.valueOf(logAddedG), 3);
         this.logAddedBInputTextField = new JTextField(String.valueOf(logAddedB), 3);
 
-        logAddedRInputTextField.addActionListener(e -> updateLogAddedColor());
-        logAddedGInputTextField.addActionListener(e -> updateLogAddedColor());
-        logAddedBInputTextField.addActionListener(e -> updateLogAddedColor());
+        logAddedRInputTextField.addActionListener(e -> updateColor(2));
+        logAddedGInputTextField.addActionListener(e -> updateColor(2));
+        logAddedBInputTextField.addActionListener(e -> updateColor(2));
 
         this.logAddedColorPreviewButton = createColorPreviewButton(logAddedR, logAddedG, logAddedB, this::openLogAddedColorChooser);
 
@@ -136,9 +137,9 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
         this.logRemovedGInputTextField = new JTextField(String.valueOf(logRemovedG), 3);
         this.logRemovedBInputTextField = new JTextField(String.valueOf(logRemovedB), 3);
 
-        logRemovedRInputTextField.addActionListener(e -> updateLogRemovedColor());
-        logRemovedGInputTextField.addActionListener(e -> updateLogRemovedColor());
-        logRemovedBInputTextField.addActionListener(e -> updateLogRemovedColor());
+        logRemovedRInputTextField.addActionListener(e -> updateColor(3));
+        logRemovedGInputTextField.addActionListener(e -> updateColor(3));
+        logRemovedBInputTextField.addActionListener(e -> updateColor(3));
 
         this.logRemovedColorPreviewButton = createColorPreviewButton(logRemovedR, logRemovedG, logRemovedB, this::openLogRemovedColorChooser);
 
@@ -170,15 +171,14 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
 
     @Override
     public void initListeners() {
-        this.addAISettingsListener(
-                newColor -> {
-                    settingsUpdates.put("boundingBoxColor", newColor);
-                    AIMsLogger.TRACE("Bounding box color changed to: " + Arrays.toString(newColor));
-                    if(Arrays.equals(settings.getBoundingBoxColor(), newColor))
-                        settingsUpdates.remove("boundingBoxColor");
-                    updateApplyButtonState();
-                }
-        );
+        this.addAISettingsListener((key, newColor) -> {
+            switch (key) {
+                case "boundingBoxColor" -> handleColorChange(key, newColor, settings.getBoundingBoxColor());
+                case "logAddedColor" -> handleColorChange(key, newColor, settings.getLogAddedColor());
+                case "logRemovedColor" -> handleColorChange(key, newColor, settings.getLogRemovedColor());
+                default -> AIMsLogger.WARN("Unknown color key: " + key);
+            }
+        });
 
         // Sync text field to slider (with validation)
         confThresholdTextField.addActionListener(e -> {
@@ -495,8 +495,7 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
                         bInputTextField.setText(String.valueOf(selectedColor.getBlue()));
 
                         this.boundingBoxColor = new int[]{selectedColor.getRed(), selectedColor.getGreen(), selectedColor.getBlue()};
-                        fireBoundingBoxColorChangedEvent(boundingBoxColor);
-                    }
+                        fireColorChangedEvent("boundingBoxColor", this.boundingBoxColor);                    }
                 },
                 null
         );
@@ -527,7 +526,7 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
                                 selectedColor.getGreen(),
                                 selectedColor.getBlue()
                         };
-                        fireLogAddedColorChangedEvent(this.logAddedColor);
+                        fireColorChangedEvent("logAddedColor", this.logAddedColor);
                     }
                 },
                 null
@@ -559,7 +558,7 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
                                 selectedColor.getGreen(),
                                 selectedColor.getBlue()
                         };
-                        fireLogRemovedColorChangedEvent(this.logRemovedColor);
+                        fireColorChangedEvent("logRemovedColor", this.logRemovedColor);
                     }
                 },
                 null
@@ -582,7 +581,7 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
         }
     }
 
-    private void updateBoundingBoxColor() {
+    private void updateColor(int key) {
         try {
             int r = Integer.parseInt(rInputTextField.getText());
             int g = Integer.parseInt(gInputTextField.getText());
@@ -605,59 +604,15 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
             colorPreviewButton.setBackground(new Color(r, g, b));
 
             // Fire the event
-            fireBoundingBoxColorChangedEvent(this.boundingBoxColor);
-
+            switch (key) {
+                case 1 -> fireColorChangedEvent("boundingBoxColor", this.boundingBoxColor);
+                case 2 -> fireColorChangedEvent("logAddedColor", this.logAddedColor);
+                case 3 -> fireColorChangedEvent("logRemovedColor", this.logRemovedColor);
+                default -> AIMsLogger.WARN("Unknown color key: " + key);
+            }
         } catch (NumberFormatException ex) {
             // Handle invalid input (non-numeric)
             System.err.println("Invalid RGB input. Must be a number between 0-255.");
-        }
-    }
-
-    private void updateLogAddedColor() {
-        try {
-            int r = Integer.parseInt(logAddedRInputTextField.getText());
-            int g = Integer.parseInt(logAddedGInputTextField.getText());
-            int b = Integer.parseInt(logAddedBInputTextField.getText());
-
-            r = Math.max(0, Math.min(255, r));
-            g = Math.max(0, Math.min(255, g));
-            b = Math.max(0, Math.min(255, b));
-
-            logAddedRInputTextField.setText(String.valueOf(r));
-            logAddedGInputTextField.setText(String.valueOf(g));
-            logAddedBInputTextField.setText(String.valueOf(b));
-
-            this.logAddedColor = new int[]{r, g, b};
-            logAddedColorPreviewButton.setBackground(new Color(r, g, b));
-
-            fireLogAddedColorChangedEvent(this.logAddedColor);
-
-        } catch (NumberFormatException ex) {
-            System.err.println("Invalid RGB input for log added color. Must be a number between 0-255.");
-        }
-    }
-
-    private void updateLogRemovedColor() {
-        try {
-            int r = Integer.parseInt(logRemovedRInputTextField.getText());
-            int g = Integer.parseInt(logRemovedGInputTextField.getText());
-            int b = Integer.parseInt(logRemovedBInputTextField.getText());
-
-            r = Math.max(0, Math.min(255, r));
-            g = Math.max(0, Math.min(255, g));
-            b = Math.max(0, Math.min(255, b));
-
-            logRemovedRInputTextField.setText(String.valueOf(r));
-            logRemovedGInputTextField.setText(String.valueOf(g));
-            logRemovedBInputTextField.setText(String.valueOf(b));
-
-            this.logRemovedColor = new int[]{r, g, b};
-            logRemovedColorPreviewButton.setBackground(new Color(r, g, b));
-
-            fireLogRemovedColorChangedEvent(this.logRemovedColor);
-
-        } catch (NumberFormatException ex) {
-            System.err.println("Invalid RGB input for log removed color. Must be a number between 0-255.");
         }
     }
 
@@ -666,26 +621,22 @@ public class AISettingsPanel extends JPanel implements SettingsUI {
     }
 
     /**
-     * Fires an event to all registered listeners when the bounding box color changes.
+     * Fires an event to all registered listeners when any color changes.
      */
-    private void fireBoundingBoxColorChangedEvent(int[] newColor) {
-        BoundingBoxColorChangeEvent event = new BoundingBoxColorChangeEvent(newColor);
+    private void fireColorChangedEvent(String key, int[] newColor) {
         for (AISettingsListener listener : listeners) {
-            listener.onBoundingBoxColorChanged(event.newColor());
+            listener.onColorChanged(key, newColor);
         }
     }
 
-    private void fireLogAddedColorChangedEvent(int[] newColor) {
-        settingsUpdates.put("logAddedColor", newColor);
-        if (Arrays.equals(settings.getLogAddedColor(), newColor))
-            settingsUpdates.remove("logAddedColor");
-        updateApplyButtonState();
-    }
+    private void handleColorChange(String key, int[] newColor, int[] originalColor) {
+        settingsUpdates.put(key, newColor);
+        AIMsLogger.TRACE(key + " changed to: " + Arrays.toString(newColor));
 
-    private void fireLogRemovedColorChangedEvent(int[] newColor) {
-        settingsUpdates.put("logRemovedColor", newColor);
-        if (Arrays.equals(settings.getLogRemovedColor(), newColor))
-            settingsUpdates.remove("logRemovedColor");
+        if (Arrays.equals(originalColor, newColor)) {
+            settingsUpdates.remove(key);
+        }
+
         updateApplyButtonState();
     }
 }


### PR DESCRIPTION
# Bug Fix

## Problem
Too many functions already do the same thing in the file.

## Solution
I abstracted the color update process into a single reusable method, updateColor(...), which takes in the setting key (e.g., "boundingBoxColor"), the corresponding RGB text fields, and the preview button. This method handles input validation, field updates, and color preview refresh and puts the appropriate value into settingsUpdates. We also generalized the color-change event logic into a single fireColorChanged(...) method to remove the need for three separate fireXXXColorChangedEvent methods.

## Testing
I tested all the ways the colors can be saved, and they all work. Nothing gets saved prematurely.

*(This PR body was generated automatically. Please review and update if needed.)*
